### PR TITLE
Bugfix broken makefile and install in ExamplePackage

### DIFF
--- a/ExamplePackage/Makefile
+++ b/ExamplePackage/Makefile
@@ -2,27 +2,13 @@
 
 ## You can use CC CFLAGS LD LDFLAGS CXX CXXFLAGS AR RANLIB READELF STRIP after include env.mak
 include /env.mak
-
 EXEC= examplePkg
 OBJS= examplePkg.o
-
-SUBDIR=ui WIZARD_UIFILES
-
-.PHONY: all install $(SUBDIR)
-
-all: $(EXEC) $(SUBDIR)
-
-$(SUBDIR):
-	@echo "===>" $@
-	GenerateModuleFiles.php $@ $@
-	$(MAKE) -C $@ INSTALLDIR=$(INSTALLDIR)/$@ DESTDIR=$(DESTDIR) PREFIX=$(PREFIX) $(MAKECMDGOALS);
-	@echo "<===" $@
-
-packageinstall: $(SUBDIR)
-
-install: $(EXEC) $(SUBDIR)
-	mkdir -p $(DESTDIR)/usr/local/bin/
-	install $< $(DESTDIR)/usr/local/bin/
-
+all: $(EXEC)
+$(EXEC): $(OBJS)
+        $(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
+install: $(EXEC)
+        mkdir -p $(DESTDIR)/usr/bin/
+        install $< $(DESTDIR)/usr/bin/
 clean:
-	rm -rf *.o $(EXEC)
+        rm -rf *.o $(EXEC)

--- a/ExamplePackage/SynoBuildConf/install
+++ b/ExamplePackage/SynoBuildConf/install
@@ -10,21 +10,14 @@ mkdir -p $PKG_DIR
 source /pkgscripts/include/pkg_util.sh
 
 create_package_tgz() {
-	local firewere_version=
-	local package_tgz_dir=/tmp/_package_tgz
-	local binary_dir=$package_tgz_dir/usr/local/bin
-
-	### clear destination directory
-	rm -rf $package_tgz_dir && mkdir -p $package_tgz_dir
-
-	### install needed file into PKG_DIR
-	mkdir -p $binary_dir
-	cp -av examplePkg $binary_dir
-	make install DESTDIR="$package_tgz_dir" INSTALLDIR="$package_tgz_dir"
-	make packageinstall DESTDIR="$package_tgz_dir" PKG_DIR="$PKG_DIR"
-
-	### create package.tgz $1: source_dir $2: dest_dir
-	pkg_make_package $package_tgz_dir "${PKG_DIR}"
+        local firewere_version=
+        local package_tgz_dir=/tmp/_package_tgz
+        local binary_dir=$package_tgz_dir/usr/bin
+        rm -rf $package_tgz_dir && mkdir -p $package_tgz_dir
+        mkdir -p $binary_dir
+        cp -av examplePkg $binary_dir
+        make install DESTDIR="$package_tgz_dir"
+        pkg_make_package $package_tgz_dir "${PKG_DIR}"
 }
 
 create_spk(){


### PR DESCRIPTION
In current main branch on Synology repo that this was forked from, the ExamplePackage cannot be build and packaged, as errors stop that process. This fixes the Makefile an SynoBuildConf/install to match what is on the syno guidance page https://help.synology.com/developer-guide/getting_started/first_package.html , which resolves the issue.

Fixes https://github.com/SynologyOpenSource/ExamplePackages/issues/3 